### PR TITLE
Replace utf8 with utf-8 for gettext compatibility

### DIFF
--- a/tinycss/__init__.py
+++ b/tinycss/__init__.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     tinycss
     -------

--- a/tinycss/color3.py
+++ b/tinycss/color3.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     tinycss.colors3
     ---------------

--- a/tinycss/css21.py
+++ b/tinycss/css21.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     tinycss.css21
     -------------

--- a/tinycss/decoding.py
+++ b/tinycss/decoding.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     tinycss.decoding
     ----------------

--- a/tinycss/page3.py
+++ b/tinycss/page3.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     tinycss.page3
     ------------------

--- a/tinycss/parsing.py
+++ b/tinycss/parsing.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     tinycss.parsing
     ---------------

--- a/tinycss/speedups.pyx
+++ b/tinycss/speedups.pyx
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     tinycss.speedups
     ----------------

--- a/tinycss/tests/__init__.py
+++ b/tinycss/tests/__init__.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     Test suite for tinycss
     ----------------------

--- a/tinycss/tests/speed.py
+++ b/tinycss/tests/speed.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     Speed tests
     -----------

--- a/tinycss/tests/test_api.py
+++ b/tinycss/tests/test_api.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     Tests for the public API
     ------------------------

--- a/tinycss/tests/test_color3.py
+++ b/tinycss/tests/test_color3.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     Tests for the CSS 3 color parser
     --------------------------------

--- a/tinycss/tests/test_css21.py
+++ b/tinycss/tests/test_css21.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     Tests for the CSS 2.1 parser
     ----------------------------

--- a/tinycss/tests/test_decoding.py
+++ b/tinycss/tests/test_decoding.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     Tests for decoding bytes to Unicode
     -----------------------------------

--- a/tinycss/tests/test_page3.py
+++ b/tinycss/tests/test_page3.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     Tests for the Paged Media 3 parser
     ----------------------------------

--- a/tinycss/tests/test_tokenizer.py
+++ b/tinycss/tests/test_tokenizer.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     Tests for the tokenizer
     -----------------------

--- a/tinycss/token_data.py
+++ b/tinycss/token_data.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     tinycss.token_data
     ------------------

--- a/tinycss/tokenizer.py
+++ b/tinycss/tokenizer.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     tinycss.tokenizer
     -----------------


### PR DESCRIPTION
See: http://stackoverflow.com/questions/4370035/django-makemessages-errors-unknown-encoding-utf8

This will fix:
<pre>
CommandError: errors happened while running xgettext on __init__.py
xgettext: ./venv/lib/python3.4/site-packages/tinycss/__init__.py:1: Unknown encoding "utf8". Proceeding with ASCII instead.
xgettext: Non-ASCII string at ./venv/lib/python3.4/site-packages/tinycss/__init__.py:34.
          Please specify the source encoding through --from-code or through a comment
          as specified in http://www.python.org/peps/pep-0263.html.
</pre>